### PR TITLE
Increase default IQE timeout from 30 minutes to 2 hours

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -100,7 +100,7 @@ spec:
     - name: IQE_CJI_TIMEOUT
       type: string
       description: This is the time to wait for smoke test to complete or fail
-      default: 30min
+      default: 2h
 
     - name: IQE_ENV
       type: string

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -62,7 +62,7 @@ spec:
     - name: IQE_CJI_TIMEOUT
       type: string
       description: This is the time to wait for smoke test to complete or fail
-      default: 30min
+      default: 2h
 
     - name: IQE_ENV
       type: string


### PR DESCRIPTION
Some integration tests take about 90 minutes to run.