### PR TITLE
Increase pipeline and task timeouts

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -7,6 +7,9 @@ metadata:
     build.appstudio.redhat.com/pipeline: "bonfire"
 
 spec:
+  timeouts:
+    pipeline: 5h
+
   params:
     - name: URL
       type: string

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -99,6 +99,7 @@ spec:
   steps:
     - name: deploy-iqe-cji
       image: "$(params.BONFIRE_IMAGE)"
+      timeout: 5h
       env:
         - name: OC_LOGIN_TOKEN
           valueFrom:


### PR DESCRIPTION
The default value of one hour is not long enough for full smoke test runs.