### PR TITLE
[COST-5755] Enabling Konflux Slack notifications

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -343,3 +343,23 @@ spec:
 
           - name: pathInRepo
             value: tasks/teardown.yaml
+
+    - name: slack-notification
+      params:
+        - name: message
+          value: |
+            :x: Pipeline `<$(context.pipelineRun.name)>` has completed with status `$(tasks.status)`.
+            See details: <https://console.redhat.com/application-pipeline/workspaces/cost-mgmt-dev/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>.
+        - name: secret-name
+          value: "slack-webhook-notification-secret"
+        - name: key-name
+          value: "webhook-url"
+      taskRef:
+        params:
+          - name: name
+            value: slack-webhook-notification
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:dc17b70633363d78414b8c06dc1660d25742935f106a6116995638e1210c2730
+          - name: kind
+            value: task
+        resolver: bundles

--- a/pipelines/basic_no_iqe.yaml
+++ b/pipelines/basic_no_iqe.yaml
@@ -195,3 +195,23 @@ spec:
 
           - name: pathInRepo
             value: tasks/teardown.yaml
+
+    - name: slack-notification
+      params:
+        - name: message
+          value: |
+            :x: Pipeline `<$(context.pipelineRun.name)>` has completed with status `$(tasks.status)`.
+            See details: <https://console.redhat.com/application-pipeline/workspaces/cost-mgmt-dev/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>.
+        - name: secret-name
+          value: "slack-webhook-notification-secret"
+        - name: key-name
+          value: "webhook-url"
+      taskRef:
+        params:
+          - name: name
+            value: slack-webhook-notification
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:dc17b70633363d78414b8c06dc1660d25742935f106a6116995638e1210c2730
+          - name: kind
+            value: task
+        resolver: bundles


### PR DESCRIPTION
This change will enable Slack notifications on `#cost-mgmt-bots` channel on each pipeline run (failed or not).