### PR TITLE
use buildah-oci-ta v0.2 and update tasks

### DIFF
--- a/pipelines/pipeline-build.yaml
+++ b/pipelines/pipeline-build.yaml
@@ -128,7 +128,7 @@ spec:
             value: git-clone-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:dc810a4b4e7b593813120ce1db575e8dddff734c56d98a241c0bd768bec851d8
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:36d98ab04eaac2c964149060c773ac20df42f91527db6c40b7b250e6eeff5821
 
           - name: kind
             value: task
@@ -163,7 +163,7 @@ spec:
             value: prefetch-dependencies-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:90e1a4fd2c588f3f3b32d3bc7aa1e29ae0233dd8f976fa0532df508e60a345b3
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:ddf5bdddc91f6d343178ea217fcefb25537e6490d8f67acd0c0422f44a687607
 
           - name: kind
             value: task
@@ -218,7 +218,7 @@ spec:
             value: buildah-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.3@sha256:53f5e957a1c8104ad4ed7049dc4835176fdd59585a9df9d4501e93459cb4b45b
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:36e3369a209a50cca70af3b213ae3c20c756beff6e5f424b33915b1f050b48c6
 
           - name: kind
             value: task
@@ -270,7 +270,7 @@ spec:
             value: clair-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:4584647138af3efe5f1c523d0f56103c3b9647325634d17f04e2198a2c3c0c26
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:f636f2cbe91d9d4d9685a38c8bc680a36e17f568ec0e60a93da82d1284b488c5
 
           - name: kind
             value: task


### PR DESCRIPTION
- revert to version 0.2 of `buildah-oci-ta` . 
- ref: [migration doc](https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.3/MIGRATION.md#action-from-users)