### PR TITLE
update build-pipeline shas

### DIFF
--- a/pipelines/pipeline-build.yaml
+++ b/pipelines/pipeline-build.yaml
@@ -101,7 +101,7 @@ spec:
             value: init
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:63eb4a4c0cfb491276bff86fdad1c96bf238506388848e79001058450a8e843a
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:737682d073a65a486d59b2b30e3104b93edd8490e0cd5e9b4a39703e47363f0f
 
           - name: kind
             value: task
@@ -128,7 +128,7 @@ spec:
             value: git-clone-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:944e7698434862d7d295b69718accf01b0e0cbeccd44b6d68d65e67f14b97d82
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:9709088bf3c581d4763e9804d9ee3a1f06ad6a61c23237277057c4f0cdc4f9c3
 
           - name: kind
             value: task
@@ -163,7 +163,7 @@ spec:
             value: prefetch-dependencies-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:752230a646483aebd465a942aef4f35c08e67185609ac26e19a3b931de9b7b0a
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:153ef0382deef840d155f5146f134f39b480523a7d5c38ba9fea2b58792dd4b5
 
           - name: kind
             value: task
@@ -218,7 +218,7 @@ spec:
             value: buildah-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:8cdd218d094e586ece807eb0c61b42cd6baa32c7397fe4ce9d33f6239b78c3cd
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:174d3c420f8c9ad4ea7a16c673ac999090d66d5df1a1da278b12d87fa105503f
 
           - name: kind
             value: task
@@ -244,7 +244,7 @@ spec:
             value: deprecated-image-check
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:a0a5b05286e3df5045432b3da3cc11224a831e05bc77c927cbfd00381f7f6235
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5d63b920b71192906fe4d6c4903f594e6f34c5edcff9d21714a08b5edcfbc667
 
           - name: kind
             value: task
@@ -270,7 +270,7 @@ spec:
             value: clair-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:c45aae9e7d4449e1ea3ef0fc59dec84b77831329ae2b03c1578e02bd051a2863
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:712afcf63f3b5a97c371d37e637efbcc9e1c7ad158872339d00adc6413cd8851
 
           - name: kind
             value: task
@@ -293,7 +293,7 @@ spec:
             value: ecosystem-cert-preflight-checks
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:00b13d06d17328e105b11619ee4db98b215ca6ac02314a4776aa5fc2a974f9c1
 
           - name: kind
             value: task
@@ -325,7 +325,7 @@ spec:
             value: sast-snyk-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:6673cbd19e4f1872dd194c91d0b1fe14cacd3768050f6516d3888f660e0732de
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:a1cb59ed66a7be1949c9720660efb0a006e95ef05b3f67929dd8e310e1d7baef
 
           - name: kind
             value: task
@@ -351,7 +351,7 @@ spec:
             value: clamav-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7595ba07e6bf3737a7ce51e0d75e43bd2658a9b9c5b59e161c005029ac758b3d
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:62c835adae22e36fce6684460b39206bc16752f1a4427cdbba4ee9afdd279670
 
           - name: kind
             value: task
@@ -430,7 +430,7 @@ spec:
             value: apply-tags
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:5e5f290359fd34ae4cc77cbbba6ef8c9907d752572d6dc2a00f5a4c504eb48bb
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:61c90b1c94a2a11cb11211a0d65884089b758c34254fcec164d185a402beae22
 
           - name: kind
             value: task
@@ -460,7 +460,7 @@ spec:
             value: push-dockerfile-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:443e665458bd44f029c8e44e8d4c44e4faa8c533f129014ccb3c4c51fd89bbfc
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:55a4ff2910ae2e4502f3841719935d37578bd52156bc789fcdf45ff48c2b048b
 
           - name: kind
             value: task
@@ -481,7 +481,7 @@ spec:
             value: rpms-signature-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:afc2b5a80e654bd6b180637a8e0004727cb3c77619f46e6527f2cf32069b01f3
 
           - name: kind
             value: task

--- a/update_sha.py
+++ b/update_sha.py
@@ -1,0 +1,69 @@
+import json
+import re
+import urllib.request
+from pathlib import Path
+
+# Filepath to your YAML file
+file_path = Path("pipelines/pipeline-build.yaml")
+
+# Base URL for the container registry API (Quay.io in this case)
+registry_api_url = "https://quay.io/api/v1/repository"
+
+# Regular expression to match the task bundle lines
+sha_pattern = re.compile(
+    r"value: quay\.io/konflux-ci/tekton-catalog/(.*?):(.*?)@sha256:[a-f0-9]+"
+)
+
+
+# Function to fetch the sha256 digest for a specific tag of a task
+def fetch_sha_for_tag(task_name, tag):
+    try:
+        # Construct the API URL for the task and tag
+        url = f"{registry_api_url}/konflux-ci/tekton-catalog/{task_name}/tag/?specificTag={tag}"
+        with urllib.request.urlopen(url) as response:
+            data = json.loads(response.read().decode())
+            tags = data.get("tags", [])
+
+            # Find the tag without the "expiration" key
+            for tag_info in tags:
+                if "expiration" not in tag_info and "manifest_digest" in tag_info:
+                    return tag_info["manifest_digest"]
+    except Exception as e:
+        print(f"Error fetching SHA for {task_name}:{tag}: {e}")
+    return None
+
+
+# Read the file and extract tasks and tags
+with file_path.open("r") as file:
+    content = file.read()
+
+# Extract task names and tags from the file
+tasks_with_tags = {
+    (match.group(1), match.group(2)) for match in sha_pattern.finditer(content)
+}
+
+# Fetch the sha256 values for all tasks and tags
+latest_shas = {}
+for task_name, tag in tasks_with_tags:
+    if latest_sha := fetch_sha_for_tag(task_name, tag):
+        latest_shas[(task_name, tag)] = latest_sha
+    else:
+        print(f"Warning: Could not fetch SHA for {task_name}:{tag}")
+
+
+# Replace old sha256 values with the latest ones
+def replace_sha(match):
+    task_name = match.group(1)
+    tag = match.group(2)
+    task_line = match.group(0).split("@sha256:")[0]
+    new_sha = latest_shas.get((task_name, tag))
+    return f"{task_line}@{new_sha}" if new_sha else match.group(0)
+
+
+updated_content = sha_pattern.sub(replace_sha, content)
+
+# Write the updated content back to the file
+with file_path.open("w") as file:
+    file.write(updated_content)
+
+print("SHA256 values updated successfully!")


### PR DESCRIPTION
## Summary by Sourcery

Update build pipeline task bundle SHA256 values to their latest versions

Build:
- Add a Python script to automatically update SHA256 values for Tekton catalog task bundles in the build pipeline configuration

Chores:
- Update multiple Tekton task bundle references with their latest SHA256 digests