### PR TITLE
only notify failures for push events

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -340,12 +340,16 @@ spec:
       when:
         - input: $(tasks.status)
           operator: in
-          values: [ "Failed", "Completed" ]
+          values: [ "Failed", "Cancelled" ]
+        - input: "{{ event_type }}"
+          operator: in
+          values:
+            - "push"
       params:
         - name: message
           value: |
-            :x: Pipeline `<$(context.pipelineRun.name)>` has failed or completed with skipped tasks.
-            See details: <https://console.redhat.com/application-pipeline/workspaces/cost-mgmt-dev/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>.
+            :x: Pipeline `$(context.pipelineRun.name)` has $(tasks.status).
+            See details: <https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cost-mgmt-dev-tenant/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>
         - name: secret-name
           value: "slack-webhook-notification-secret"
         - name: key-name

--- a/pipelines/basic_no_iqe.yaml
+++ b/pipelines/basic_no_iqe.yaml
@@ -192,12 +192,16 @@ spec:
       when:
         - input: $(tasks.status)
           operator: in
-          values: [ "Failed", "Completed" ]
+          values: [ "Failed", "Cancelled" ]
+        - input: "{{ event_type }}"
+          operator: in
+          values:
+            - "push"
       params:
         - name: message
           value: |
-            :x: Pipeline `<$(context.pipelineRun.name)>` has failed or completed with skipped tasks.
-            See details: <https://console.redhat.com/application-pipeline/workspaces/cost-mgmt-dev/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>.
+            :x: Pipeline `$(context.pipelineRun.name)` has $(tasks.status).
+            See details: <https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cost-mgmt-dev-tenant/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>
         - name: secret-name
           value: "slack-webhook-notification-secret"
         - name: key-name

--- a/pipelines/pipeline-build.yaml
+++ b/pipelines/pipeline-build.yaml
@@ -101,7 +101,7 @@ spec:
             value: init
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:737682d073a65a486d59b2b30e3104b93edd8490e0cd5e9b4a39703e47363f0f
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:aac8127bc10c95fae3ca1248c1dd96576315f3313bca90c5c9378dbf37954a08
 
           - name: kind
             value: task
@@ -128,7 +128,7 @@ spec:
             value: git-clone-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:9709088bf3c581d4763e9804d9ee3a1f06ad6a61c23237277057c4f0cdc4f9c3
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0761f97595d42c87c076797e0d0f66ff572146cad958106b7f5446b182d03394
 
           - name: kind
             value: task
@@ -218,7 +218,7 @@ spec:
             value: buildah-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:174d3c420f8c9ad4ea7a16c673ac999090d66d5df1a1da278b12d87fa105503f
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:2466d6f8787363825fea838598e91ece2c80e063796613a5c13b28ab690dfbb2
 
           - name: kind
             value: task
@@ -244,7 +244,7 @@ spec:
             value: deprecated-image-check
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5d63b920b71192906fe4d6c4903f594e6f34c5edcff9d21714a08b5edcfbc667
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
 
           - name: kind
             value: task
@@ -270,7 +270,7 @@ spec:
             value: clair-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:712afcf63f3b5a97c371d37e637efbcc9e1c7ad158872339d00adc6413cd8851
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
 
           - name: kind
             value: task
@@ -325,7 +325,7 @@ spec:
             value: sast-snyk-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:a1cb59ed66a7be1949c9720660efb0a006e95ef05b3f67929dd8e310e1d7baef
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:eea1112fb6e8ef91f1fb5692f7724773bce1d287cbf8b8803a609c2d3ff7b1c1
 
           - name: kind
             value: task
@@ -351,7 +351,7 @@ spec:
             value: clamav-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:62c835adae22e36fce6684460b39206bc16752f1a4427cdbba4ee9afdd279670
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:11b1684965b64f1fa7c65f90a3524413022246a3863eaba188c84eb4bf0b687a
 
           - name: kind
             value: task
@@ -360,7 +360,7 @@ spec:
           operator: in
           values:
             - "false"
-    
+
     - name: sast-shell-check
       params:
       - name: image-digest
@@ -378,7 +378,7 @@ spec:
         - name: name
           value: sast-shell-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:a591675c72f06fb9c5b1a3d60e6e4c58e4df5f7da180c7a4691a692a6e7e6496
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
         - name: kind
           value: task
         resolver: bundles
@@ -386,8 +386,8 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values:
-        - "false" 
-    
+        - "false"
+
     - name: sast-unicode-check
       params:
       - name: image-url
@@ -403,7 +403,7 @@ spec:
         - name: name
           value: sast-unicode-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:424f2f659c02998dc3a43e1ce869e3148982c59adb74f953f8fa91ff1c9ab86e
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:4581e7ef9edc2166a8aef7eed8dd21090393307a40dbc4841266bcac88a7709f
         - name: kind
           value: task
         resolver: bundles
@@ -430,7 +430,7 @@ spec:
             value: apply-tags
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:61c90b1c94a2a11cb11211a0d65884089b758c34254fcec164d185a402beae22
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:4973fa42a8f06238613447fbdb3d0c55eb2d718fd16f2f2591a577c29c1edb17
 
           - name: kind
             value: task
@@ -460,7 +460,7 @@ spec:
             value: push-dockerfile-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:55a4ff2910ae2e4502f3841719935d37578bd52156bc789fcdf45ff48c2b048b
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:c4f87c44c4cf99f3d90435d72ad93e550b14d2928ba943715daf9015bcc1af73
 
           - name: kind
             value: task
@@ -481,7 +481,7 @@ spec:
             value: rpms-signature-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:afc2b5a80e654bd6b180637a8e0004727cb3c77619f46e6527f2cf32069b01f3
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:998b5466417c324aea94d3e8b302c558aeb13f746976d89a4ff85f1b84a42c2b
 
           - name: kind
             value: task
@@ -507,7 +507,7 @@ spec:
       when:
         - input: $(tasks.status)
           operator: in
-          values: [ "Failed", "Completed" ]
+          values: [ "Failed", "Cancelled" ]
         - input: "{{ event_type }}"
           operator: in
           values:
@@ -515,8 +515,8 @@ spec:
       params:
         - name: message
           value: |
-            :x: Pipeline `<$(context.pipelineRun.name)>` has failed or completed with skipped tasks.
-            See details: <https://console.redhat.com/application-pipeline/workspaces/cost-mgmt-dev/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>.
+            :x: Pipeline `$(context.pipelineRun.name)` has $(tasks.status).
+            See details: <https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/cost-mgmt-dev-tenant/applications/$(params.APP_NAME)/pipelineruns/$(context.pipelineRun.name)|Pipeline Run>
         - name: secret-name
           value: "slack-webhook-notification-secret"
         - name: key-name


### PR DESCRIPTION
## Summary by Sourcery

Modify Slack notification settings to only send notifications for push events and failed or cancelled pipeline runs

Enhancements:
- Update SHA update script to process multiple pipeline YAML files simultaneously
- Improve error handling and SHA fetching in update script

Chores:
- Update pipeline configuration to restrict Slack notifications to push events