### PR TITLE
[COST-6310] Add CHECK_RUN_ID environment variable to deploy.yaml

### DIFF
--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -155,6 +155,11 @@ spec:
             fieldRef:
               fieldPath: metadata.labels['pac.test.appstudio.openshift.io/pull-request']
 
+        - name: CHECK_RUN_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/check-run-id']
+
       script: |
         #!/bin/bash
         set -ex


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add CHECK_RUN_ID environment variable to the deployment task to expose the check-run-id label