### PR TITLE
add PIPELINE_RUN_NAME env var

### DIFF
--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -126,39 +126,13 @@ spec:
         - name: DEPLOY_TIMEOUT
           value: "$(params.DEPLOY_TIMEOUT)"
 
-        - name: AWS_CREDENTIALS_EPH
-          valueFrom:
-            secretKeyRef:
-              name: ephemeral-env-credentials
-              key: aws
-
-        - name: GCP_CREDENTIALS_EPH
-          valueFrom:
-            secretKeyRef:
-              name: ephemeral-env-credentials
-              key: gcp
-
-        - name: OCI_CREDENTIALS_EPH
-          valueFrom:
-            secretKeyRef:
-              name: ephemeral-env-credentials
-              key: oci
-
-        - name: OCI_CONFIG_EPH
-          valueFrom:
-            secretKeyRef:
-              name: ephemeral-env-credentials
-              key: oci_config
-
         - name: PR_NUMBER
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['pac.test.appstudio.openshift.io/pull-request']
 
-        - name: CHECK_RUN_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/check-run-id']
+        - name: PIPELINE_RUN_NAME
+          value: $(params.PIPELINE_RUN_NAME)
 
       script: |
         #!/bin/bash


### PR DESCRIPTION
## Summary by Sourcery

Update the deploy task to expose the pipeline run name as an environment variable and clean up unused secret- and metadata-based variables

Enhancements:
- Add PIPELINE_RUN_NAME environment variable to the deploy task
- Remove AWS_CREDENTIALS_EPH, GCP_CREDENTIALS_EPH, OCI_CREDENTIALS_EPH, and OCI_CONFIG_EPH environment variables
- Remove CHECK_RUN_ID environment variable