### PR TITLE
add PIPELINE_RUN_NAME to params too

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -221,6 +221,9 @@ spec:
         - name: DEPLOY_TIMEOUT
           value: "$(params.DEPLOY_TIMEOUT)"
 
+        - name: PIPELINE_RUN_NAME
+          value: $(context.pipelineRun.name)
+
       runAfter:
         - reserve-namespace
 

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -65,6 +65,9 @@ spec:
       type: string
       description: "Deploy timeout"
       default: "30min"
+
+    - name: PIPELINE_RUN_NAME
+      type: string
   steps:
     - name: deploy-application
       image: "$(params.BONFIRE_IMAGE)"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add PIPELINE_RUN_NAME parameter to deploy.yaml to allow passing the pipeline run name