### PR TITLE
Add CHECK_RUN_ID to deploy.yaml for enhanced pipeline tracking

### DIFF
--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -134,6 +134,11 @@ spec:
             fieldRef:
               fieldPath: metadata.labels['pac.test.appstudio.openshift.io/pull-request']
 
+        - name: CHECK_RUN_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/check-run-id']
+
         - name: PIPELINE_RUN_NAME
           value: $(params.PIPELINE_RUN_NAME)
 


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce CHECK_RUN_ID environment variable sourced from the ‘pac.test.appstudio.openshift.io/check-run-id’ metadata label for deployment tasks