### PR TITLE
Increase default IQE_CJI_TIMEOUT value to 6 hours

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -100,7 +100,7 @@ spec:
     - name: IQE_CJI_TIMEOUT
       type: string
       description: This is the time to wait for smoke test to complete or fail
-      default: 2h
+      default: 6h
 
     - name: IQE_ENV
       type: string

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -66,7 +66,7 @@ spec:
     - name: IQE_CJI_TIMEOUT
       type: string
       description: This is the time to wait for smoke test to complete or fail
-      default: 2h
+      default: 6h
 
     - name: IQE_ENV
       type: string


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Raise the default IQE_CJI_TIMEOUT from 2h to 6h in pipeline and task YAML definitions