### PR TITLE
Set timeout for run-iqe-cji to 5 minutes

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -240,6 +240,7 @@ spec:
             value: tasks/deploy.yaml
 
     - name: run-iqe-cji
+      timeout: "5m"
       params:
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set a 5-minute timeout for the run-iqe-cji step in pipelines/basic.yaml