### PR TITLE
Update run-iqe-cji timeout to 6 hours

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -240,7 +240,7 @@ spec:
             value: tasks/deploy.yaml
 
     - name: run-iqe-cji
-      timeout: "5m"
+      timeout: "6h"
       params:
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Increase run-iqe-cji task timeout to 6 hours in the basic pipeline configuration.