### PR TITLE
Increase IQE_CJI_TIMEOUT and run-iqe-cji timeout to 8 hours

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -240,7 +240,7 @@ spec:
             value: tasks/deploy.yaml
 
     - name: run-iqe-cji
-      timeout: "8h"
+      timeout: "$(params.IQE_CJI_TIMEOUT)"
       params:
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -103,7 +103,7 @@ spec:
   steps:
     - name: deploy-iqe-cji
       image: "$(params.BONFIRE_IMAGE)"
-      timeout: "8h"
+      timeout: "$(params.IQE_CJI_TIMEOUT)"
       env:
         - name: OC_LOGIN_TOKEN
           valueFrom:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Extend IQE_CJI_TIMEOUT defaults and related run-iqe-cji task and pipeline timeouts from 6h to 8h