### PR TITLE
Set hardcoded timeout for run-iqe-cji and deploy-iqe-cji to 8 hours

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -240,7 +240,7 @@ spec:
             value: tasks/deploy.yaml
 
     - name: run-iqe-cji
-      timeout: "$(params.IQE_CJI_TIMEOUT)"
+      timeout: "8h"
       params:
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -103,7 +103,7 @@ spec:
   steps:
     - name: deploy-iqe-cji
       image: "$(params.BONFIRE_IMAGE)"
-      timeout: "$(params.IQE_CJI_TIMEOUT)"
+      timeout: "8h"
       env:
         - name: OC_LOGIN_TOKEN
           valueFrom:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace dynamic IQE_CJI_TIMEOUT parameter with fixed "8h" timeout for both run-iqe-cji and deploy-iqe-cji tasks.