### PR TITLE
Update AWS_SECRET and BUCKET names to hccm-konflux-artifacts

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -56,7 +56,7 @@ spec:
 
     - name: AWS_SECRET
       type: string
-      default: rh-artifacts-bucket
+      default: hccm-konflux-artifacts
       description: Secret with connection details to S3
 
     - name: BONFIRE_COMPONENT_NAME

--- a/pipelines/basic_no_iqe.yaml
+++ b/pipelines/basic_no_iqe.yaml
@@ -56,7 +56,7 @@ spec:
 
     - name: AWS_SECRET
       type: string
-      default: rh-artifacts-bucket
+      default: hccm-konflux-artifacts
       description: Secret with connection details to S3
 
     - name: BONFIRE_COMPONENT_NAME

--- a/tasks/teardown.yaml
+++ b/tasks/teardown.yaml
@@ -24,7 +24,7 @@ spec:
 
     - name: AWS_SECRET
       type: string
-      default: rh-artifacts-bucket
+      default: hccm-konflux-artifacts
       description: Secret with connection details to S3
 
     - name: ARTIFACTS_KEY
@@ -93,7 +93,7 @@ spec:
           value: us-east-1
 
         - name: BUCKET
-          value: rh-artifacts-bucket
+          value: hccm-konflux-artifacts
 
         - name: ARTIFACTS_KEY
           value: $(params.ARTIFACTS_KEY)


### PR DESCRIPTION
## Summary by Sourcery

Update S3 artifact bucket references across Tekton pipeline and teardown tasks

Enhancements:
- Change AWS_SECRET default from "rh-artifacts-bucket" to "hccm-konflux-artifacts" in pipeline and teardown configs
- Update BUCKET environment variable to "hccm-konflux-artifacts" in teardown task