### PR TITLE
Add PIPELINE_RUN_NAME to basic_no_iqe pipeline configuration

### DIFF
--- a/pipelines/basic_no_iqe.yaml
+++ b/pipelines/basic_no_iqe.yaml
@@ -150,6 +150,9 @@ spec:
         - name: DEPLOY_TIMEOUT
           value: "$(params.DEPLOY_TIMEOUT)"
 
+        - name: PIPELINE_RUN_NAME
+          value: "$(context.pipelineRun.name)"
+
       runAfter:
         - reserve-namespace
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add PIPELINE_RUN_NAME environment variable to the basic_no_iqe pipeline to provide the current PipelineRun name to subsequent tasks.