### PR TITLE
Add custom check run ID generation for scheduled jobs

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -152,6 +152,11 @@ spec:
       description:
       default: "insights-production"
 
+    - name: IS_SCHEDULED_TEST_JOB
+      type: string
+      description: "Whether this is a scheduled test job"
+      default: "false"
+
   results:
     - name: ARTIFACTS_URL
       description: URL for the test's artifacts
@@ -304,6 +309,9 @@ spec:
 
         - name: PIPELINE_RUN_NAME
           value: $(context.pipelineRun.name)
+
+        - name: IS_SCHEDULED_TEST_JOB
+          value: "$(params.IS_SCHEDULED_TEST_JOB)"
 
       runAfter:
         - deploy-application

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -100,6 +100,12 @@ spec:
 
     - name: PIPELINE_RUN_NAME
       type: string
+
+    - name: IS_SCHEDULED_TEST_JOB
+      type: string
+      description: "Whether this is a scheduled test job or not"
+      default: "false"
+
   steps:
     - name: deploy-iqe-cji
       image: "$(params.BONFIRE_IMAGE)"
@@ -185,6 +191,9 @@ spec:
 
         - name: PIPELINE_RUN_NAME
           value: $(params.PIPELINE_RUN_NAME)
+
+        - name: IS_SCHEDULED_TEST_JOB
+          value: $(params.IS_SCHEDULED_TEST_JOB)
 
       script: |
         #!/bin/bash


### PR DESCRIPTION
## Summary by Sourcery

Add a new `IS_SCHEDULED_TEST_JOB` parameter to pipeline and task definitions to explicitly mark and propagate scheduled test jobs through the CI workflow.

New Features:
- Introduce `IS_SCHEDULED_TEST_JOB` parameter in `run-iqe-cji.yaml` and `basic.yaml` pipeline definitions to flag scheduled test jobs.

Enhancements:
- Pass the `IS_SCHEDULED_TEST_JOB` flag into relevant pipeline steps to ensure scheduled jobs are recognized at runtime.