### PR TITLE
Revert changes: restore repo state to commit 88c17dc

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -184,8 +184,29 @@ spec:
 
           - name: pathInRepo
             value: tasks/reserve-namespace.yaml
+    - name: check-pr-labels
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: "$(params.URL)"
 
+          - name: revision
+            value: "$(params.REVISION)"
+
+          - name: pathInRepo
+            value: tasks/check-pr-labels.yaml
+      params:
+        - name: PR_NUMBER
+          value: "$(context.pipelineRun.metadata.labels['pac.test.appstudio.openshift.io/pull-request'])"
     - name: deploy-application
+      runAfter:
+        - reserve-namespace
+        - check-pr-labels
+      when:
+        - input: $(tasks.check-pr-labels.results.should_deploy)
+          operator: in
+          values: [ "true" ]
       params:
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"
@@ -229,9 +250,6 @@ spec:
         - name: PIPELINE_RUN_NAME
           value: $(context.pipelineRun.name)
 
-      runAfter:
-        - reserve-namespace
-
       taskRef:
         resolver: git
         params:
@@ -245,6 +263,13 @@ spec:
             value: tasks/deploy.yaml
 
     - name: run-iqe-cji
+      runAfter:
+        - check-pr-labels
+        - deploy-application
+      when:
+        - input: $(tasks.check-pr-labels.results.should_deploy)
+          operator: in
+          values: [ "true" ]
       timeout: "8h"
       params:
         - name: BONFIRE_IMAGE
@@ -312,9 +337,6 @@ spec:
 
         - name: IS_SCHEDULED_TEST_JOB
           value: "$(params.IS_SCHEDULED_TEST_JOB)"
-
-      runAfter:
-        - deploy-application
 
       taskRef:
         resolver: git

--- a/pipelines/basic_no_iqe.yaml
+++ b/pipelines/basic_no_iqe.yaml
@@ -111,8 +111,29 @@ spec:
 
           - name: pathInRepo
             value: tasks/reserve-namespace.yaml
+    - name: check-pr-labels
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: "$(params.URL)"
 
+          - name: revision
+            value: "$(params.REVISION)"
+
+          - name: pathInRepo
+            value: tasks/check-pr-labels.yaml
+      params:
+        - name: PR_NUMBER
+          value: "$(context.pipelineRun.metadata.labels['pac.test.appstudio.openshift.io/pull-request'])"
     - name: deploy-application
+      runAfter:
+        - reserve-namespace
+        - check-pr-labels
+      when:
+        - input: $(tasks.check-pr-labels.results.should_deploy)
+          operator: in
+          values: [ "true" ]
       params:
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"
@@ -152,9 +173,6 @@ spec:
 
         - name: PIPELINE_RUN_NAME
           value: "$(context.pipelineRun.name)"
-
-      runAfter:
-        - reserve-namespace
 
       taskRef:
         resolver: git

--- a/tasks/check-pr-labels.yaml
+++ b/tasks/check-pr-labels.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: check-pr-labels
+spec:
+  params:
+    - name: PR_NUMBER
+      type: string
+  results:
+    - name: should_deploy
+      description: Whether the pipeline should proceed with deploy
+  steps:
+    - name: run-check
+      image: python:3.11-slim
+      env:
+        - name: PR_NUMBER
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pac.test.appstudio.openshift.io/pull-request']
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        python3 - <<'EOF'
+        import json
+        import os
+        import sys
+        import urllib.request
+        from urllib.error import HTTPError
+
+        def get_pr_labels(pr_number: str, owner: str, repo: str) -> list[str]:
+            url = f"https://api.github.com/repos/project-koku/koku/pulls/{pr_number}"
+            try:
+                with urllib.request.urlopen(url) as response:
+                    data = json.loads(response.read())
+                    return [label["name"] for label in data.get("labels", [])]
+            except HTTPError as e:
+                print(f"[ERROR] GitHub API error: {e.code} - {e.reason}")
+                print(e.read().decode())
+                sys.exit(0)
+            except Exception as e:
+                print(f"[ERROR] Unexpected error: {e}")
+                sys.exit(0)
+
+        def main():
+            pr_number = os.environ.get("PR_NUMBER", "")
+            owner = os.environ.get("GITHUB_OWNER", "project-koku")
+            repo = os.environ.get("GITHUB_REPO", "koku")
+
+            if not pr_number:
+                print("[INFO] No PR number. Skipping label check.")
+                print("true", file=open("/tekton/results/should_deploy", "w"))
+                return
+
+            labels = get_pr_labels(pr_number, owner, repo)
+            print(f"[INFO] Labels found: {labels}")
+
+            if "run-jenkins-tests" in labels:
+                print("[INFO] PR labeled to run Jenkins tests. Skipping Tekton deploy.")
+                print("false", file=open("/tekton/results/should_deploy", "w"))
+                return
+
+            if "smokes-required" in labels and not any(l.endswith("smoke-tests") for l in labels):
+                print("[ERROR] PR is missing required smoke-tests label.")
+                sys.exit(1)
+
+            print("[INFO] Label check passed. Proceeding.")
+            print("true", file=open("/tekton/results/should_deploy", "w"))
+
+        if __name__ == "__main__":
+            main()
+        EOF


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new PR label check task to gate deployments and tests based on GitHub pull request labels, and integrate it into the basic pipelines by adjusting task dependencies and conditional execution.

New Features:
- Add a Tekton Task `check-pr-labels` to fetch PR labels and determine if the pipeline should proceed with deployment

Enhancements:
- Integrate `check-pr-labels` into basic.yaml and basic_no_iqe.yaml pipelines before the `deploy-application` and `run-iqe-cji` tasks
- Adjust `runAfter` dependencies and add `when` conditions to only execute deployment and IQE tests when `should_deploy` is true