### PR TITLE
use the namespace output to describe namespace

### DIFF
--- a/tasks/reserve-namespace.yaml
+++ b/tasks/reserve-namespace.yaml
@@ -53,7 +53,7 @@ spec:
 
         ns=$(bonfire namespace reserve --pool "$BONFIRE_EPHEMERAL_ENV_NAMESPACE_POOL" --duration 6h30m)
 
-        namespace_info=$(bonfire namespace describe $ns --output json)
+        namespace_info=$(bonfire namespace describe "$ns" --output json)
         echo $namespace_info | jq -j '.namespace' | tee $(results.NS.path)
 
         # Get the console URL

--- a/tasks/reserve-namespace.yaml
+++ b/tasks/reserve-namespace.yaml
@@ -51,9 +51,9 @@ spec:
         echo "Connecting to the ephemeral namespace cluster"
         oc_wrapper login --token="$OC_LOGIN_TOKEN" --server="$OC_LOGIN_SERVER"
 
-        bonfire namespace reserve --pool "$BONFIRE_EPHEMERAL_ENV_NAMESPACE_POOL" --duration 6h30m
+        ns=$(bonfire namespace reserve --pool "$BONFIRE_EPHEMERAL_ENV_NAMESPACE_POOL" --duration 6h30m)
 
-        namespace_info=$(bonfire namespace describe --output json)
+        namespace_info=$(bonfire namespace describe $ns --output json)
         echo $namespace_info | jq -j '.namespace' | tee $(results.NS.path)
 
         # Get the console URL


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Store the output of bonfire namespace reserve in a variable and pass it to bonfire namespace describe to fetch the correct namespace info