### PR TITLE
update task shas

### DIFF
--- a/pipelines/pipeline-build.yaml
+++ b/pipelines/pipeline-build.yaml
@@ -163,7 +163,7 @@ spec:
             value: prefetch-dependencies-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d08e349032c57367d543c0bbd070386709614ade1db8e5eddeab29b1338f6653
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:098322d6b789824f716f2d9caca1862d4afdc083ebaaee61aadd22a8c179480a
 
           - name: kind
             value: task
@@ -218,7 +218,7 @@ spec:
             value: buildah-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:820e397596f9816c953e16328afa496337a2ede6b457fe600a40d44ebca5a16f
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:e24c062961fd8c200e2d1e08393e0c347f1b42141f2b76f28b5145b6c5bbb27a
 
           - name: kind
             value: task
@@ -244,7 +244,7 @@ spec:
             value: deprecated-image-check
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:c49732039f105de809840be396f83ead8c46f6a6948e1335b76d37e9eb469574
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:2c32152a55f6bfba67b41be456da46b6e109bb3e348e25220eed4eed149958c5
 
           - name: kind
             value: task


### PR DESCRIPTION
## Summary by Sourcery

Update pipeline build configuration to reference new SHAs for Tekton catalog tasks

Enhancements:
- Update SHA for task-prefetch-dependencies-oci-ta bundle
- Bump buildah-oci-ta bundle to new SHA and version 0.5
- Refresh SHA for deprecated-image-check task bundle version 0.5