### PR TITLE
feat(ci-manager): add ONPREM job support (COST-7403)

### DIFF
--- a/koku-ci-management/Makefile
+++ b/koku-ci-management/Makefile
@@ -4,38 +4,12 @@
 
 .PHONY: help login env health status suspend resume trigger jobs pipelines logs watch pods cleanup
 
+# Job selector: standard | onprem | all (default: standard for mutating ops, all for read ops)
+JOB ?= standard
+
 # Default target
 help:
-	@echo "Koku CI Management"
-	@echo "============================="
-	@echo ""
-	@echo "Available targets:"
-	@echo "  login      - Login to Konflux cluster and switch to correct project"
-	@echo "  env        - Print export KUBECONFIG for current shell (use: eval \$(make env))"
-	@echo "  health     - Check CronJob health and detect failed executions"
-	@echo "  status     - Show current CronJob status, recent jobs and pipelines"
-	@echo "  suspend    - Suspend scheduled jobs (e.g., for holidays)"
-	@echo "  resume     - Resume scheduled jobs"
-	@echo "  trigger    - Trigger a manual scheduled test job"
-	@echo "  jobs       - Show recent jobs (last 10)"
-	@echo "  pipelines  - Show recent PipelineRuns (last 10)"
-	@echo "  logs       - Show logs for the most recent job"
-	@echo "  watch      - Watch jobs in real-time"
-	@echo "  pods       - Show pods for the most recent job"
-	@echo "  cleanup    - Clean up old jobs (older than 7 days)"
-	@echo ""
-	@echo "Examples:"
-	@echo "  make login"
-	@echo "  make health"
-	@echo "  make status"
-	@echo "  make suspend    # Suspend before holidays"
-	@echo "  make resume     # Resume after holidays"
-	@echo "  make trigger"
-	@echo "  make pipelines"
-	@echo "  make logs"
-	@echo ""
-	@echo "Repository: koku-ci"
-	@echo "Team: Cost Management"
+	@./koku-ci-manager.sh help
 
 # Login to Konflux cluster
 login:
@@ -46,25 +20,35 @@ login:
 env:
 	@echo 'export KUBECONFIG="$(CURDIR)/konflux-cost-mgmt-dev.yaml"'
 
-# Check CronJob health
+# Check CronJob health (both jobs by default)
+# Usage: make health              # check both
+#        make health JOB=onprem  # check onprem only
 health:
-	@./koku-ci-manager.sh health
+	@./koku-ci-manager.sh health $(JOB)
 
-# Show current status
+# Show current status for all scheduled jobs
 status:
 	@./koku-ci-manager.sh status
 
-# Suspend scheduled jobs (disable CronJob)
+# Suspend scheduled job(s)
+# Usage: make suspend             # suspend standard job
+#        make suspend JOB=onprem # suspend onprem job
+#        make suspend JOB=all    # suspend both (e.g. for holidays)
 suspend:
-	@./koku-ci-manager.sh suspend
+	@./koku-ci-manager.sh suspend $(JOB)
 
-# Resume scheduled jobs (enable CronJob)
+# Resume scheduled job(s)
+# Usage: make resume             # resume standard job
+#        make resume JOB=onprem # resume onprem job
+#        make resume JOB=all    # resume both
 resume:
-	@./koku-ci-manager.sh resume
+	@./koku-ci-manager.sh resume $(JOB)
 
-# Trigger manual scheduled test job
+# Trigger a manual run
+# Usage: make trigger             # trigger standard job
+#        make trigger JOB=onprem # trigger onprem job
 trigger:
-	@./koku-ci-manager.sh trigger
+	@./koku-ci-manager.sh trigger $(JOB)
 
 # Show recent jobs
 jobs:

--- a/koku-ci-management/README.md
+++ b/koku-ci-management/README.md
@@ -1,15 +1,19 @@
 # Koku CI Management
 
-This directory contains tools to manage Koku CI scheduled test jobs (integration tests) that run automatically every Saturday at 2 AM UTC.
+This directory contains tools to manage Koku CI scheduled test jobs that run automatically every day.
+
+## Scheduled Jobs
+
+| Job | CronJob | Schedule | Description |
+|-----|---------|----------|-------------|
+| `standard` | `koku-scheduled-integration-test` | 2 AM UTC daily | Standard daily smoke tests |
+| `onprem` | `koku-onprem-scheduled-integration-test` | 3 AM UTC daily | ONPREM=True validation (`-m cost_ocp_on_prem`) |
 
 ## Configuration
 
 **No configuration needed!** Everything is pre-configured and ready to use.
 
-The scripts use the following default settings:
 - **Namespace**: `cost-mgmt-dev-tenant`
-- **CronJob**: `koku-scheduled-integration-test`
-- **Test Scenario**: `koku-scheduled-test-job`
 - **Kubeconfig**: `konflux-cost-mgmt-dev.yaml` (included in repository)
 
 > **Note**: The `konflux-cost-mgmt-dev.yaml` file is tracked in git but ignored for local changes. This prevents accidentally committing sensitive tokens that are added during authentication. The file will be modified locally when you login, but these changes won't be staged for commit.
@@ -19,41 +23,83 @@ The scripts use the following default settings:
 **Always login to Konflux cluster before using any commands.**
 A browser window will open to complete the login process.
 
-### Using Make
+**Why does `oc project` still show another cluster (e.g. hccm-prod)?**  
+`make login` runs in a subprocess. Your **current terminal** still uses the default kubeconfig (e.g. production). After login, run **one** of the following in the **same terminal** so `oc`/`kubectl` point to Konflux:
+
 ```bash
-# Navigate to the koku-ci-management directory
+# Option 1: from koku-ci-management/
+eval $(make env)
+
+# Option 2: copy the export line printed at the end of 'make login'
+export KUBECONFIG="/path/to/koku-ci-management/konflux-cost-mgmt-dev.yaml"
+```
+
+Then `oc project` will show `cost-mgmt-dev-tenant` on the Konflux server.
+
+```bash
 cd koku-ci-management
-
-# Login to Konflux cluster
 make login
-
-# Login to Konflux with specific project
-make login -p koku-dev-tenant
+eval $(make env)
 ```
 
+## Available Commands
 
-### Login Helper Options
+### Status & Health
+
 ```bash
-# Login to Konflux with default project
-./konflux-login.sh
-
-# Show help
-./konflux-login.sh --help
-```
-
-### Available Commands (Using Make)
-```bash
-# Show current status
+# Show status for both scheduled jobs + recent pipeline runs
 make status
 
-# Trigger manual scheduled test job
+# Check health of both jobs (last execution success/failure)
+make health
+
+# Check health of the ONPREM job only
+make health JOB=onprem
+
+# Check health of the standard job only
+make health JOB=standard
+```
+
+### Trigger Manual Runs
+
+```bash
+# Trigger the standard job manually (default)
 make trigger
+
+# Trigger the ONPREM job manually
+make trigger JOB=onprem
+```
+
+### Suspend / Resume
+
+```bash
+# Suspend the standard job (default)
+make suspend
+
+# Suspend the ONPREM job
+make suspend JOB=onprem
+
+# Suspend BOTH jobs (e.g., before holidays)
+make suspend JOB=all
+
+# Resume the standard job (default)
+make resume
+
+# Resume the ONPREM job
+make resume JOB=onprem
+
+# Resume BOTH jobs
+make resume JOB=all
+```
+
+### Pipelines & Jobs
+
+```bash
+# Show recent pipeline runs
+make pipelines
 
 # Show recent jobs
 make jobs
-
-# Show recent pipeline runs
-make pipelines
 
 # Show logs for most recent job
 make logs
@@ -65,65 +111,71 @@ make watch
 make cleanup
 ```
 
-### Using Script Directly
+### Using the Script Directly
+
 ```bash
-# Show help
+# Show help with all options
 ./koku-ci-manager.sh help
 
-# Show current status
+# Show status
 ./koku-ci-manager.sh status
 
-# Trigger manual build
-./koku-ci-manager.sh trigger
+# Trigger ONPREM job
+./koku-ci-manager.sh trigger onprem
 
-# Show last 5 jobs
-./koku-ci-manager.sh jobs 5
+# Check health of all jobs
+./koku-ci-manager.sh health all
+
+# Suspend both jobs
+./koku-ci-manager.sh suspend all
+
+# Show last 5 pipeline runs
+./koku-ci-manager.sh pipelines 5
 
 # Show logs for specific job
-./koku-ci-manager.sh logs koku-manual-run-20250127-1430
+./koku-ci-manager.sh logs koku-onprem-manual-run-20250421-1430
 ```
 
-## What It Does
+## How It Works
 
-The scheduled test job system:
+Each scheduled job:
 
-1. **Automatically runs** every Saturday at 2 AM UTC via CronJob
-2. **Finds the latest released snapshot** of the Koku component
-3. **Triggers integration tests** against that snapshot
-4. **Validates** that the system is working correctly
+1. **Runs automatically** via a Kubernetes CronJob at the configured schedule
+2. **Finds the latest released snapshot** of the Koku component (push event + AutoReleased)
+3. **Labels the snapshot** to trigger the associated `IntegrationTestScenario`
+4. **Provisions an ephemeral environment**, runs the tests, then tears it down
 
-
-
+The `onprem` job additionally deploys with `ONPREM=True` and uses the `cost_ocp_on_prem` pytest marker.
 
 ## Troubleshooting
 
-### Check if CronJob is Working
+### Check CronJobs
+
 ```bash
-kubectl get cronjob koku-scheduled-integration-test -n cost-mgmt-dev-tenant
+kubectl get cronjob -n cost-mgmt-dev-tenant | grep scheduled
 ```
 
 ### View Recent Jobs
+
 ```bash
 kubectl get jobs -n cost-mgmt-dev-tenant --sort-by=.metadata.creationTimestamp
 ```
 
 ### Check Job Logs
+
 ```bash
 kubectl logs job/<job-name> -n cost-mgmt-dev-tenant
 ```
 
 ### Common Issues
 
-1. **Not Logged In**: If you get authentication errors, run `make login` first
-2. **Kubeconfig Missing**: If you get "kubeconfig file not found", create the kubeconfig file with OIDC configuration
-4. **No Snapshots**: If no valid snapshots are found, check if the Koku component has been built and released recently
-5. **Permission Issues**: Ensure you're logged in with proper permissions using `make login`
-
-
+1. **Not Logged In**: Run `make login` then `eval $(make env)`
+2. **No Snapshots Found**: Check if the Koku component has been built and released recently
+3. **Permission Issues**: Ensure you're logged in with proper permissions using `make login`
+4. **CronJob Suspended**: Run `make status` to check, then `make resume JOB=all` to re-enable
 
 ## Related Documentation
 
 - [Konflux Integration Testing](https://konflux-ci.dev/docs/testing/integration/rerunning/)
 - [Koku CI Repository](../README.md)
 - [Konflux Release Data](https://github.com/redhat-appstudio/konflux-release-data)
-

--- a/koku-ci-management/koku-ci-manager.sh
+++ b/koku-ci-management/koku-ci-manager.sh
@@ -9,9 +9,22 @@ set -euo pipefail
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 NAMESPACE="cost-mgmt-dev-tenant"
-CRONJOB_NAME="koku-scheduled-integration-test"
-TEST_SCENARIO_NAME="koku-scheduled-test-job"
 KONFLUX_KUBECONFIG="$SCRIPT_DIR/konflux-cost-mgmt-dev.yaml"
+
+# Job definitions: name -> "cronjob_name:scenario_name:description"
+declare -A JOB_CRONJOB
+declare -A JOB_SCENARIO
+declare -A JOB_DESC
+
+JOB_CRONJOB["standard"]="koku-scheduled-integration-test"
+JOB_SCENARIO["standard"]="koku-scheduled-test-job"
+JOB_DESC["standard"]="Standard daily smoke tests (2 AM UTC)"
+
+JOB_CRONJOB["onprem"]="koku-onprem-scheduled-integration-test"
+JOB_SCENARIO["onprem"]="koku-scheduled-onprem-test-job"
+JOB_DESC["onprem"]="ONPREM=True daily validation (3 AM UTC, -m cost_ocp_on_prem)"
+
+ALL_JOBS=("standard" "onprem")
 
 # Set KUBECONFIG to use Konflux credentials
 if [[ -f "$KONFLUX_KUBECONFIG" ]]; then
@@ -23,6 +36,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Helper functions
@@ -42,6 +56,22 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+log_section() {
+    echo -e "${CYAN}=== $1 ===${NC}"
+}
+
+# Resolve job key, accepting "standard", "onprem", or "all"
+resolve_job() {
+    local job="${1:-standard}"
+    case "$job" in
+        standard|onprem|all) echo "$job" ;;
+        *)
+            log_error "Unknown job: '$job'. Valid values: standard, onprem, all"
+            exit 1
+            ;;
+    esac
+}
+
 # Check if kubectl is available and user is logged in
 check_prerequisites() {
     if ! command -v kubectl &> /dev/null; then
@@ -59,109 +89,122 @@ check_prerequisites() {
     fi
 }
 
-# Check CronJob health and detect failed executions
-check_cronjob_health() {
+# Check CronJob health for a single job key
+check_cronjob_health_single() {
+    local job="$1"
+    local cronjob_name="${JOB_CRONJOB[$job]}"
+    local desc="${JOB_DESC[$job]}"
+
+    log_section "$job ($desc)"
+
     local last_schedule
     local last_success
-    local failed_job_name
-    
-    last_schedule=$(kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o jsonpath='{.status.lastScheduleTime}' 2>/dev/null || echo "")
-    last_success=$(kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o jsonpath='{.status.lastSuccessfulTime}' 2>/dev/null || echo "")
-    
+    last_schedule=$(kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o jsonpath='{.status.lastScheduleTime}' 2>/dev/null || echo "")
+    last_success=$(kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o jsonpath='{.status.lastSuccessfulTime}' 2>/dev/null || echo "")
+
     if [[ -z "$last_schedule" ]]; then
         log_warning "CronJob has never been executed"
         return 1
     fi
-    
+
     if [[ -z "$last_success" ]]; then
         log_error "CronJob has been scheduled but NEVER succeeded!"
         log_info "Last scheduled: $last_schedule"
         return 1
     fi
-    
-    # Compare timestamps
+
     if [[ "$last_schedule" != "$last_success" ]]; then
         log_error "FAILURE DETECTED! Last scheduled job did not complete successfully"
         log_info "Last scheduled: $last_schedule"
         log_info "Last successful: $last_success"
         echo
-        
-        # Try to find the failed job in recent events
+
         log_warning "Checking for recent failures..."
         local recent_events
         recent_events=$(kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' 2>/dev/null | \
                        grep -E "(FailedCreatePodSandBox|Failed|Error|CrashLoopBackOff|ImagePullBackOff)" | \
-                       grep "$CRONJOB_NAME" | tail -5)
-        
+                       grep "$cronjob_name" | tail -5 || true)
+
         if [[ -n "$recent_events" ]]; then
             echo "$recent_events"
         else
             log_info "No recent error events found (job may have been deleted)"
         fi
-        
-        echo
-        log_warning "The scheduled job was executed but failed to complete."
-        log_warning "This could be due to:"
-        log_warning "  - Infrastructure issues (node problems, container runtime)"
-        log_warning "  - Resource constraints (CPU, memory)"
-        log_warning "  - Application errors in the job"
-        
+
         return 1
     else
-        log_success "CronJob health: OK (last execution was successful)"
+        log_success "Health: OK (last execution was successful)"
+        log_info "Last scheduled:  $last_schedule"
+        log_info "Last successful: $last_success"
         return 0
     fi
 }
 
+# Check health for one or all jobs
+check_cronjob_health() {
+    local job="${1:-all}"
+    local exit_code=0
+
+    if [[ "$job" == "all" ]]; then
+        for j in "${ALL_JOBS[@]}"; do
+            check_cronjob_health_single "$j" || exit_code=1
+            echo
+        done
+    else
+        check_cronjob_health_single "$job" || exit_code=1
+    fi
+
+    return $exit_code
+}
+
+# Show status for a single job
+show_status_single() {
+    local job="$1"
+    local cronjob_name="${JOB_CRONJOB[$job]}"
+    local desc="${JOB_DESC[$job]}"
+
+    log_section "$job — $desc"
+
+    local suspended
+    suspended=$(kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "false")
+    if [[ "$suspended" == "true" ]]; then
+        log_warning "⚠️  STATUS: SUSPENDED"
+    else
+        log_success "STATUS: ACTIVE"
+    fi
+
+    local schedule
+    schedule=$(kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o jsonpath='{.spec.schedule}' 2>/dev/null || echo "Not found")
+    log_info "Schedule:        $schedule"
+
+    local last_schedule
+    last_schedule=$(kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o jsonpath='{.status.lastScheduleTime}' 2>/dev/null || echo "Never")
+    log_info "Last execution:  $last_schedule"
+
+    local last_success
+    last_success=$(kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o jsonpath='{.status.lastSuccessfulTime}' 2>/dev/null || echo "Never")
+    log_info "Last successful: $last_success"
+}
+
 # Show current status
 show_status() {
-    log_info "=== Koku CI Management Status ==="
+    log_section "Koku CI Management Status"
     echo
-    
-    # Check if suspended
-    if is_cronjob_suspended; then
-        log_warning "⚠️  STATUS: SUSPENDED - Scheduled jobs will NOT run"
-        log_info "To resume: make resume (or ./koku-ci-manager.sh resume)"
+
+    for j in "${ALL_JOBS[@]}"; do
+        show_status_single "$j"
         echo
-    else
-        log_success "STATUS: ACTIVE - Scheduled jobs will run normally"
-        echo
-    fi
-    
-    # CronJob schedule
-    local schedule
-    schedule=$(kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.schedule}' 2>/dev/null || echo "Not found")
-    log_info "Schedule: $schedule"
-    
-    # Last execution
-    local last_schedule
-    last_schedule=$(kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o jsonpath='{.status.lastScheduleTime}' 2>/dev/null || echo "Never")
-    log_info "Last execution: $last_schedule"
-    
-    # Last successful execution
-    local last_success
-    last_success=$(kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o jsonpath='{.status.lastSuccessfulTime}' 2>/dev/null || echo "Never")
-    log_info "Last successful: $last_success"
-    
-    # Active jobs
-    local active_jobs
-    active_jobs=$(kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o jsonpath='{.status.active}' 2>/dev/null || echo "0")
-    log_info "Active jobs: $active_jobs"
-    
-    echo
-    # Check health
-    check_cronjob_health
-    
-    echo
-    log_info "=== Recent Jobs ==="
+    done
+
+    log_section "Recent Jobs"
     kubectl get jobs -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp | tail -5
-    
+
     echo
-    log_info "=== Recent PipelineRuns ==="
+    log_section "Recent PipelineRuns"
     kubectl get pipelineruns -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp | tail -5
-    
+
     echo
-    log_info "=== Running Pipelines ==="
+    log_section "Running Pipelines"
     local running_pipelines
     running_pipelines=$(kubectl get pipelineruns -n "$NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[-1].reason}{"\n"}{end}' 2>/dev/null | grep -E '\tRunning$' | wc -l)
     if [[ "$running_pipelines" -gt 0 ]]; then
@@ -174,12 +217,17 @@ show_status() {
 
 # Trigger manual scheduled test job
 trigger_manual() {
-    local job_name="koku-manual-run-$(date +%Y%m%d-%H%M%S)"
-    
-    log_info "Triggering manual scheduled test job: $job_name"
-    
-    # Use the complex command from documentation
-    kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o json | \
+    local job
+    job=$(resolve_job "${1:-standard}")
+
+    local cronjob_name="${JOB_CRONJOB[$job]}"
+    local desc="${JOB_DESC[$job]}"
+    local run_name="koku-${job}-manual-run-$(date +%Y%m%d-%H%M%S)"
+
+    log_info "Triggering manual job for: $job ($desc)"
+    log_info "Job name: $run_name"
+
+    kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o json | \
     jq 'del(
         .metadata.ownerReferences,
         .metadata.uid,
@@ -192,29 +240,29 @@ trigger_manual() {
       ) |
       .kind = "Job" |
       .apiVersion = "batch/v1" |
-      .metadata.name = "'"$job_name"'" |
+      .metadata.name = "'"$run_name"'" |
       .spec = .spec.jobTemplate.spec' | \
     kubectl create -f -
-    
-    log_success "Manual scheduled test job triggered: $job_name"
-    log_info "You can monitor it with: kubectl get jobs -n $NAMESPACE --sort-by=.metadata.creationTimestamp"
+
+    log_success "Manual job triggered: $run_name"
+    log_info "Monitor with: kubectl get jobs -n $NAMESPACE --sort-by=.metadata.creationTimestamp"
 }
 
 # Show recent jobs
 show_jobs() {
     local count=${1:-10}
-    log_info "=== Last $count Jobs ==="
+    log_section "Last $count Jobs"
     kubectl get jobs -n "$NAMESPACE" -o=custom-columns=NAME:.metadata.name,STATUS:.status.conditions[-1].type,CREATED:.metadata.creationTimestamp --sort-by=.metadata.creationTimestamp | tail -"$count"
 }
 
 # Show recent pipelines
 show_pipelines() {
     local count=${1:-10}
-    log_info "=== Last $count PipelineRuns ==="
+    log_section "Last $count PipelineRuns"
     kubectl get pipelineruns -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp | tail -"$count"
-    
+
     echo
-    log_info "=== Running Pipelines ==="
+    log_section "Running Pipelines"
     local running_pipelines
     running_pipelines=$(kubectl get pipelineruns -n "$NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions[-1].reason}{"\n"}{end}' 2>/dev/null | grep -E '\tRunning$' | wc -l)
     if [[ "$running_pipelines" -gt 0 ]]; then
@@ -228,14 +276,14 @@ show_pipelines() {
 # Show job logs
 show_logs() {
     local job_name="$1"
-    
+
     if [[ -z "$job_name" ]]; then
         log_error "Please provide a job name"
         log_info "Available jobs:"
         kubectl get jobs -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp | tail -5
         exit 1
     fi
-    
+
     log_info "Showing logs for job: $job_name"
     kubectl logs job/"$job_name" -n "$NAMESPACE" --tail=50
 }
@@ -249,12 +297,12 @@ watch_jobs() {
 # Show pods for a specific job
 show_pods() {
     local job_name="$1"
-    
+
     if [[ -z "$job_name" ]]; then
         log_error "Please provide a job name"
         exit 1
     fi
-    
+
     log_info "Pods for job: $job_name"
     kubectl get pods -n "$NAMESPACE" --selector=job-name="$job_name"
 }
@@ -263,95 +311,93 @@ show_pods() {
 cleanup_jobs() {
     local days=${1:-7}
     log_info "Cleaning up jobs older than $days days..."
-    
-    # Get jobs older than specified days
+
     local old_jobs
     old_jobs=$(kubectl get jobs -n "$NAMESPACE" -o json | \
                jq -r --arg days "$days" '
-                 .items[] | 
+                 .items[] |
                  select(.metadata.creationTimestamp | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime < (now - ($days | tonumber) * 86400)) |
                  .metadata.name')
-    
+
     if [[ -z "$old_jobs" ]]; then
         log_info "No old jobs found to clean up"
         return
     fi
-    
+
     echo "$old_jobs" | while read -r job; do
         if [[ -n "$job" ]]; then
             log_info "Deleting job: $job"
             kubectl delete job "$job" -n "$NAMESPACE" --ignore-not-found=true
         fi
     done
-    
+
     log_success "Cleanup completed"
 }
 
-# Check if CronJob is suspended
+# Check if a CronJob is suspended
 is_cronjob_suspended() {
+    local cronjob_name="$1"
     local suspended
-    suspended=$(kubectl get cronjob "$CRONJOB_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "false")
+    suspended=$(kubectl get cronjob "$cronjob_name" -n "$NAMESPACE" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "false")
     [[ "$suspended" == "true" ]]
 }
 
-# Suspend the CronJob (disable scheduled executions)
+# Suspend one or all CronJobs
 suspend_cronjob() {
-    log_info "Checking current CronJob state..."
-    
-    if is_cronjob_suspended; then
-        log_warning "CronJob '$CRONJOB_NAME' is already suspended"
-        log_info "No action needed. Use 'resume' to re-enable scheduled executions."
-        return 0
-    fi
-    
-    log_info "Suspending CronJob '$CRONJOB_NAME'..."
-    
-    if kubectl patch cronjob "$CRONJOB_NAME" -n "$NAMESPACE" \
-        --type='merge' -p='{"spec":{"suspend":true}}'; then
-        log_success "CronJob '$CRONJOB_NAME' has been SUSPENDED"
-        echo
-        log_warning "⚠️  IMPORTANT: Scheduled jobs will NOT run until you resume the CronJob"
-        log_info "To verify: make status (or ./koku-ci-manager.sh status)"
-        log_info "To resume: make resume (or ./koku-ci-manager.sh resume)"
+    local job
+    job=$(resolve_job "${1:-standard}")
+
+    local jobs_to_act=()
+    if [[ "$job" == "all" ]]; then
+        jobs_to_act=("${ALL_JOBS[@]}")
     else
-        log_error "Failed to suspend CronJob"
-        return 1
+        jobs_to_act=("$job")
     fi
+
+    for j in "${jobs_to_act[@]}"; do
+        local cronjob_name="${JOB_CRONJOB[$j]}"
+        if is_cronjob_suspended "$cronjob_name"; then
+            log_warning "[$j] CronJob '$cronjob_name' is already suspended"
+        else
+            kubectl patch cronjob "$cronjob_name" -n "$NAMESPACE" \
+                --type='merge' -p='{"spec":{"suspend":true}}'
+            log_success "[$j] CronJob '$cronjob_name' SUSPENDED"
+        fi
+    done
 }
 
-# Resume the CronJob (enable scheduled executions)
+# Resume one or all CronJobs
 resume_cronjob() {
-    log_info "Checking current CronJob state..."
-    
-    if ! is_cronjob_suspended; then
-        log_warning "CronJob '$CRONJOB_NAME' is already active (not suspended)"
-        log_info "No action needed. Scheduled jobs will run according to the schedule."
-        return 0
-    fi
-    
-    log_info "Resuming CronJob '$CRONJOB_NAME'..."
-    
-    if kubectl patch cronjob "$CRONJOB_NAME" -n "$NAMESPACE" \
-        --type='merge' -p='{"spec":{"suspend":false}}'; then
-        log_success "CronJob '$CRONJOB_NAME' has been RESUMED"
-        echo
-        log_info "✅ Scheduled jobs will now run according to the schedule"
-        log_info "To verify: make status (or ./koku-ci-manager.sh status)"
+    local job
+    job=$(resolve_job "${1:-standard}")
+
+    local jobs_to_act=()
+    if [[ "$job" == "all" ]]; then
+        jobs_to_act=("${ALL_JOBS[@]}")
     else
-        log_error "Failed to resume CronJob"
-        return 1
+        jobs_to_act=("$job")
     fi
+
+    for j in "${jobs_to_act[@]}"; do
+        local cronjob_name="${JOB_CRONJOB[$j]}"
+        if ! is_cronjob_suspended "$cronjob_name"; then
+            log_warning "[$j] CronJob '$cronjob_name' is already active"
+        else
+            kubectl patch cronjob "$cronjob_name" -n "$NAMESPACE" \
+                --type='merge' -p='{"spec":{"suspend":false}}'
+            log_success "[$j] CronJob '$cronjob_name' RESUMED"
+        fi
+    done
 }
 
 # Login to Konflux cluster
 login_to_konflux() {
     log_info "Starting Konflux login process..."
-    
-    # Check if konflux-login.sh exists
+
     local script_dir
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
     local login_script="$script_dir/konflux-login.sh"
-    
+
     if [[ -f "$login_script" ]]; then
         log_info "Using konflux-login.sh helper script..."
         "$login_script" -p "$NAMESPACE"
@@ -371,39 +417,46 @@ USAGE:
     $0 [COMMAND] [OPTIONS]
 
 COMMANDS:
-    login               Login to Konflux cluster and switch to correct project
-    health              Check CronJob health and detect failed executions
-    status              Show current CronJob status, recent jobs and pipelines
-    suspend             Suspend the CronJob (disable scheduled executions)
-    resume              Resume the CronJob (enable scheduled executions)
-    trigger             Trigger a manual scheduled test job
-    jobs [count]        Show recent jobs (default: 10)
-    pipelines [count]   Show recent PipelineRuns (default: 10)
-    logs <job-name>     Show logs for a specific job
-    watch               Watch jobs in real-time
-    pods <job-name>     Show pods for a specific job
-    cleanup [days]      Clean up old jobs (default: 7 days)
-    help                Show this help message
+    login                   Login to Konflux cluster and switch to correct project
+    health [job]            Check CronJob health (job: standard|onprem|all, default: all)
+    status                  Show status for all scheduled jobs, recent jobs and pipelines
+    suspend [job]           Suspend CronJob(s) (job: standard|onprem|all, default: standard)
+    resume [job]            Resume CronJob(s) (job: standard|onprem|all, default: standard)
+    trigger [job]           Trigger a manual run (job: standard|onprem, default: standard)
+    jobs [count]            Show recent jobs (default: 10)
+    pipelines [count]       Show recent PipelineRuns (default: 10)
+    logs <job-name>         Show logs for a specific job
+    watch                   Watch jobs in real-time
+    pods <job-name>         Show pods for a specific job
+    cleanup [days]          Clean up old jobs (default: 7 days)
+    help                    Show this help message
+
+SCHEDULED JOBS:
+    standard   CronJob: ${JOB_CRONJOB[standard]}
+               Scenario: ${JOB_SCENARIO[standard]}
+               ${JOB_DESC[standard]}
+
+    onprem     CronJob: ${JOB_CRONJOB[onprem]}
+               Scenario: ${JOB_SCENARIO[onprem]}
+               ${JOB_DESC[onprem]}
 
 EXAMPLES:
-    $0 login                     # Login to Konflux cluster
-    $0 health                    # Check if CronJob is healthy
-    $0 status                    # Show current status
-    $0 suspend                   # Suspend scheduled jobs (e.g., for holidays)
-    $0 resume                    # Resume scheduled jobs
-    $0 trigger                   # Trigger manual build
-    $0 jobs 5                    # Show last 5 jobs
-    $0 pipelines 5               # Show last 5 PipelineRuns
-    $0 logs koku-manual-run-123  # Show logs for specific job
-    $0 watch                     # Watch jobs in real-time
-    $0 cleanup 14                # Clean up jobs older than 14 days
+    $0 login                        # Login to Konflux cluster
+    $0 status                       # Show status for both jobs
+    $0 health                       # Check health of both jobs
+    $0 health onprem                # Check health of the ONPREM job only
+    $0 trigger                      # Trigger standard job manually
+    $0 trigger onprem               # Trigger ONPREM job manually
+    $0 suspend all                  # Suspend both jobs (e.g., for holidays)
+    $0 resume all                   # Resume both jobs
+    $0 suspend onprem               # Suspend only the ONPREM job
+    $0 jobs 5                       # Show last 5 jobs
+    $0 pipelines 5                  # Show last 5 PipelineRuns
+    $0 logs koku-standard-manual-run-20250421-1430
+    $0 watch                        # Watch jobs in real-time
+    $0 cleanup 14                   # Clean up jobs older than 14 days
 
-QUICK REFERENCE:
-    Schedule: Weekly on Saturdays at 2 AM UTC
-    CronJob: $CRONJOB_NAME
-    Test Scenario: $TEST_SCENARIO_NAME
-    Namespace: $NAMESPACE
-
+NAMESPACE: $NAMESPACE
 REPOSITORY: koku-ci
 TEAM: Cost Management
 
@@ -418,7 +471,7 @@ main() {
             ;;
         "health")
             check_prerequisites
-            check_cronjob_health
+            check_cronjob_health "${2:-all}"
             ;;
         "status")
             check_prerequisites
@@ -426,15 +479,15 @@ main() {
             ;;
         "suspend")
             check_prerequisites
-            suspend_cronjob
+            suspend_cronjob "${2:-standard}"
             ;;
         "resume")
             check_prerequisites
-            resume_cronjob
+            resume_cronjob "${2:-standard}"
             ;;
         "trigger")
             check_prerequisites
-            trigger_manual
+            trigger_manual "${2:-standard}"
             ;;
         "jobs")
             check_prerequisites
@@ -446,7 +499,7 @@ main() {
             ;;
         "logs")
             check_prerequisites
-            show_logs "$2"
+            show_logs "${2:-}"
             ;;
         "watch")
             check_prerequisites
@@ -454,7 +507,7 @@ main() {
             ;;
         "pods")
             check_prerequisites
-            show_pods "$2"
+            show_pods "${2:-}"
             ;;
         "cleanup")
             check_prerequisites


### PR DESCRIPTION
## Summary

- Extend `koku-ci-manager.sh` to support both scheduled jobs (`standard` and `onprem`)
- Commands that act on a single job (`trigger`, `suspend`, `resume`, `health`) now accept an optional `job` argument: `standard | onprem | all`
- `status` always shows both jobs
- Makefile exposes `JOB=` variable for all relevant targets
- README updated with the new job table and usage examples

## New scheduled job (`onprem`)

| Field | Value |
|---|---|
| CronJob | `koku-onprem-scheduled-integration-test` |
| Scenario | `koku-scheduled-onprem-test-job` |
| Schedule | 3 AM UTC daily |
| Marker | `cost_ocp_on_prem and not cost_exclude_ocp_smokes` |
| Deploy args | `ONPREM=True` |

## Usage examples

```bash
make status                  # show both jobs
make trigger JOB=onprem      # trigger ONPREM job manually
make suspend JOB=all         # suspend both (e.g. holidays)
make resume JOB=all          # resume both
make health JOB=onprem       # check ONPREM job health
```

## Test plan

- [ ] `make status` shows both `standard` and `onprem` jobs with schedule and last execution
- [ ] `make health` checks both jobs
- [ ] `make health JOB=onprem` checks only the ONPREM job
- [ ] `make trigger JOB=onprem` creates a manual job from the ONPREM CronJob
- [ ] `make suspend JOB=all` suspends both CronJobs
- [ ] `make resume JOB=all` resumes both CronJobs
- [ ] `./koku-ci-manager.sh help` shows updated help with both jobs listed

Closes COST-7403

Made with [Cursor](https://cursor.com)